### PR TITLE
Remove dynamic exception specification because it is deprecated in C++11

### DIFF
--- a/src/Utils.h
+++ b/src/Utils.h
@@ -46,7 +46,6 @@
 template<typename T>
 T fromString(const std::string& s,
              std::ios_base& (*f)(std::ios_base &) = std::dec)
-throw(std::runtime_error)
 {
   std::istringstream is(s);
   T t;


### PR DESCRIPTION
Hi, 
I am submitting a PR because C++11 has deprecated dynamic exception specification. Compiler (g++ 8.1.0, the version I am using) may report an error in src/Utils.h, line 49.

Michael