### PR TITLE
Consider timestamp in the equals operator for MemCommand

### DIFF
--- a/src/MemCommand.h
+++ b/src/MemCommand.h
@@ -130,7 +130,8 @@ class MemCommand {
   bool operator==(const MemCommand& other) const
   {
     if ((getType() == other.getType()) &&
-        (getBank() == other.getBank())
+        (getBank() == other.getBank()) &&
+        (getTimeInt64() == other.getTimeInt64())
         ) {
       return true;
     } else {


### PR DESCRIPTION
The equals operator for MemCommand does not consider the timestamps. So where we're erasing a specific command from the list, we end up deleting the first command that has the same bank and type.
For example, src/CommandAnalysis.cc, line number 195 has the statement
`          list.erase(find(list.begin(), list.end(), cmd));
`
This ends up deleting the first command it can find in the list with the same bank and type.

This resolves #68 