### PR TITLE
Delete from vector in loop

### DIFF
--- a/src/CommandAnalysis.cc
+++ b/src/CommandAnalysis.cc
@@ -193,10 +193,15 @@ void CommandAnalysis::getCommands(std::vector<MemCommand>& list, bool lastupdate
       {
           MemCommand nextWindowCmd = list[i];
           next_window_cmd_list.push_back(nextWindowCmd);
-          list.erase(find(list.begin(), list.end(), *cmd));
       }
     }
   }
+  //Delete everything that's been moved into the next_window_cmd_list from the list
+  for (size_t i = 0; i < next_window_cmd_list.size(); ++i) {
+      MemCommand cmd = next_window_cmd_list[i];
+      list.erase(find(list.begin(), list.end(), cmd));
+  }
+
   sort(list.begin(), list.end(), commandSorter);
 
   if (lastupdate && list.empty() == false) {

--- a/src/CommandAnalysis.cc
+++ b/src/CommandAnalysis.cc
@@ -173,26 +173,27 @@ void CommandAnalysis::getCommands(std::vector<MemCommand>& list, bool lastupdate
     next_window_cmd_list.clear();
   }
   for (size_t i = 0; i < list.size(); ++i) {
-    MemCommand& cmd = list[i];
-    MemCommand::cmds cmdType = cmd.getType();
+    MemCommand* cmd = &list[i];
+    MemCommand::cmds cmdType = cmd->getType();
     if (cmdType == MemCommand::ACT) {
-      activation_cycle[cmd.getBank()] = cmd.getTimeInt64();
+      activation_cycle[cmd->getBank()] = cmd->getTimeInt64();
     } else if (cmdType == MemCommand::RDA || cmdType == MemCommand::WRA) {
       // Remove auto-precharge flag from command
-      cmd.setType(cmd.typeWithoutAutoPrechargeFlag());
+      cmd->setType(cmd->typeWithoutAutoPrechargeFlag());
 
       // Add the auto precharge to the list of cached_cmds
-      int64_t preTime = max(cmd.getTimeInt64() + cmd.getPrechargeOffset(memSpec, cmdType),
-                           activation_cycle[cmd.getBank()] + memSpec.memTimingSpec.RAS);
-      list.push_back(MemCommand(MemCommand::PRE, cmd.getBank(), preTime));
+      int64_t preTime = max(cmd->getTimeInt64() + cmd->getPrechargeOffset(memSpec, cmdType),
+                           activation_cycle[cmd->getBank()] + memSpec.memTimingSpec.RAS);
+      list.push_back(MemCommand(MemCommand::PRE, cmd->getBank(), preTime));
     }
 
+    cmd = &list[i];
     if (!lastupdate && timestamp > 0) {
-      if(cmd.getTimeInt64() > timestamp)
+      if(cmd->getTimeInt64() > timestamp)
       {
           MemCommand nextWindowCmd = list[i];
           next_window_cmd_list.push_back(nextWindowCmd);
-          list.erase(find(list.begin(), list.end(), cmd));
+          list.erase(find(list.begin(), list.end(), *cmd));
       }
     }
   }

--- a/src/MemCommand.h
+++ b/src/MemCommand.h
@@ -130,7 +130,8 @@ class MemCommand {
   bool operator==(const MemCommand& other) const
   {
     if ((getType() == other.getType()) &&
-        (getBank() == other.getBank())
+        (getBank() == other.getBank()) &&
+        (getTimeInt64() == other.getTimeInt64())
         ) {
       return true;
     } else {


### PR DESCRIPTION
In CommandAnalysis::getCommands, we're looping over the command list, and possibly deleting the elements as we go over the list and moving those elements to next_window_cmd_list. 
So if the first element is a precharge that was inserted from the previous window in 
`  if (!next_window_cmd_list.empty()) {
    list.insert(list.begin(), next_window_cmd_list.begin(), next_window_cmd_list.end());
    next_window_cmd_list.clear();
  }
`
In this case, element 0 gets deleted, so element 1 is at index 0 now, which gets skipped over.  If that element is an ACT or RDA or WRA, this leads to an error.
Solves #74 