### PR TITLE
feat: add install support for DRAMPower

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ if (DRAMPOWER_USE_FETCH_CONTENT)
     if (DRAMPOWER_USE_FETCH_CONTENT_INTERNAL)
         FetchContent_Declare(
             DRAMUtils
-            URL "https://github.com/tukl-msd/DRAMUtils/archive/refs/tags/v1.10.0.tar.gz"
+            URL "https://github.com/tukl-msd/DRAMUtils/archive/refs/tags/v1.12.1.tar.gz"
             OVERRIDE_FIND_PACKAGE
         )
 

--- a/src/DRAMPower/CMakeLists.txt
+++ b/src/DRAMPower/CMakeLists.txt
@@ -41,6 +41,77 @@ add_library(DRAMPower
     DRAMPower/util/ImplicitCommandHandler.cpp
 )
 
+target_sources(DRAMPower
+PUBLIC
+    FILE_SET api
+TYPE HEADERS
+FILES
+    DRAMPower/Exceptions.h
+    DRAMPower/Types.h
+    DRAMPower/command/CmdType.h
+    DRAMPower/command/Command.h
+    DRAMPower/command/Pattern.h
+    DRAMPower/data/energy.h
+    DRAMPower/data/stats.h
+    DRAMPower/dram/Bank.h
+    DRAMPower/dram/Interface.h
+    DRAMPower/dram/Rank.h
+    DRAMPower/dram/dram_base.h
+    DRAMPower/memspec/MemSpec.h
+    DRAMPower/memspec/MemSpecDDR4.h
+    DRAMPower/memspec/MemSpecDDR5.h
+    DRAMPower/memspec/MemSpecLPDDR4.h
+    DRAMPower/memspec/MemSpecLPDDR5.h
+    DRAMPower/standards/ddr4/DDR4.h
+    DRAMPower/standards/ddr4/DDR4Core.h
+    DRAMPower/standards/ddr4/DDR4Interface.h
+    DRAMPower/standards/ddr4/core_calculation_DDR4.h
+    DRAMPower/standards/ddr4/interface_calculation_DDR4.h
+    DRAMPower/standards/ddr5/DDR5.h
+    DRAMPower/standards/ddr5/DDR5Core.h
+    DRAMPower/standards/ddr5/DDR5Interface.h
+    DRAMPower/standards/ddr5/core_calculation_DDR5.h
+    DRAMPower/standards/ddr5/interface_calculation_DDR5.h
+    DRAMPower/standards/lpddr4/LPDDR4.h
+    DRAMPower/standards/lpddr4/LPDDR4Core.h
+    DRAMPower/standards/lpddr4/LPDDR4Interface.h
+    DRAMPower/standards/lpddr4/core_calculation_LPDDR4.h
+    DRAMPower/standards/lpddr4/interface_calculation_LPDDR4.h
+    DRAMPower/standards/lpddr5/LPDDR5.h
+    DRAMPower/standards/lpddr5/LPDDR5Core.h
+    DRAMPower/standards/lpddr5/LPDDR5Interface.h
+    DRAMPower/standards/lpddr5/core_calculation_LPDDR5.h
+    DRAMPower/standards/lpddr5/interface_calculation_LPDDR5.h
+    DRAMPower/standards/test_accessor.h
+    DRAMPower/util/Deserialize.h
+    DRAMPower/util/ImplicitCommandHandler.h
+    DRAMPower/util/PatternHandler.h
+    DRAMPower/util/RegisterHelper.h
+    DRAMPower/util/Router.h
+    DRAMPower/util/Serialize.h
+    DRAMPower/util/binary_ops.h
+    DRAMPower/util/burst_storage.h
+    DRAMPower/util/bus.h
+    DRAMPower/util/bus_types.h
+    DRAMPower/util/cli_architecture_config.h
+    DRAMPower/util/clock.h
+    DRAMPower/util/command_counter.h
+    DRAMPower/util/cycle_stats.h
+    DRAMPower/util/databus.h
+    DRAMPower/util/databus_presets.h
+    DRAMPower/util/databus_types.h
+    DRAMPower/util/dbi.h
+    DRAMPower/util/dynamic_bitset.h
+    DRAMPower/util/extension_base.h
+    DRAMPower/util/extension_manager.h
+    DRAMPower/util/extension_manager_static.h
+    DRAMPower/util/extensions.h
+    DRAMPower/util/pending_stats.h
+    DRAMPower/util/pin.h
+    DRAMPower/util/pin_types.h
+    DRAMPower/util/sub_bitset.h
+)
+
 target_include_directories(DRAMPower PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_compile_features(DRAMPower PUBLIC cxx_std_17)
@@ -58,3 +129,5 @@ if(DRAMPOWER_BUILD_TESTS)
 endif()
 
 add_library(DRAMPower::DRAMPower ALIAS DRAMPower)
+
+install(TARGETS DRAMPower FILE_SET api)

--- a/src/DRAMPower/CMakeLists.txt
+++ b/src/DRAMPower/CMakeLists.txt
@@ -46,70 +46,34 @@ PUBLIC
     FILE_SET api
 TYPE HEADERS
 FILES
-    DRAMPower/Exceptions.h
     DRAMPower/Types.h
-    DRAMPower/command/CmdType.h
+    DRAMPower/Exceptions.h
+
+    DRAMPower/dram/dram_base.h
+
     DRAMPower/command/Command.h
-    DRAMPower/command/Pattern.h
     DRAMPower/data/energy.h
     DRAMPower/data/stats.h
-    DRAMPower/dram/Bank.h
-    DRAMPower/dram/Interface.h
-    DRAMPower/dram/Rank.h
-    DRAMPower/dram/dram_base.h
-    DRAMPower/memspec/MemSpec.h
-    DRAMPower/memspec/MemSpecDDR4.h
-    DRAMPower/memspec/MemSpecDDR5.h
-    DRAMPower/memspec/MemSpecLPDDR4.h
-    DRAMPower/memspec/MemSpecLPDDR5.h
-    DRAMPower/standards/ddr4/DDR4.h
-    DRAMPower/standards/ddr4/DDR4Core.h
-    DRAMPower/standards/ddr4/DDR4Interface.h
-    DRAMPower/standards/ddr4/core_calculation_DDR4.h
-    DRAMPower/standards/ddr4/interface_calculation_DDR4.h
-    DRAMPower/standards/ddr5/DDR5.h
-    DRAMPower/standards/ddr5/DDR5Core.h
-    DRAMPower/standards/ddr5/DDR5Interface.h
-    DRAMPower/standards/ddr5/core_calculation_DDR5.h
-    DRAMPower/standards/ddr5/interface_calculation_DDR5.h
-    DRAMPower/standards/lpddr4/LPDDR4.h
-    DRAMPower/standards/lpddr4/LPDDR4Core.h
-    DRAMPower/standards/lpddr4/LPDDR4Interface.h
-    DRAMPower/standards/lpddr4/core_calculation_LPDDR4.h
-    DRAMPower/standards/lpddr4/interface_calculation_LPDDR4.h
-    DRAMPower/standards/lpddr5/LPDDR5.h
-    DRAMPower/standards/lpddr5/LPDDR5Core.h
-    DRAMPower/standards/lpddr5/LPDDR5Interface.h
-    DRAMPower/standards/lpddr5/core_calculation_LPDDR5.h
-    DRAMPower/standards/lpddr5/interface_calculation_LPDDR5.h
-    DRAMPower/standards/test_accessor.h
-    DRAMPower/util/Deserialize.h
-    DRAMPower/util/ImplicitCommandHandler.h
-    DRAMPower/util/PatternHandler.h
-    DRAMPower/util/RegisterHelper.h
-    DRAMPower/util/Router.h
-    DRAMPower/util/Serialize.h
-    DRAMPower/util/binary_ops.h
-    DRAMPower/util/burst_storage.h
-    DRAMPower/util/bus.h
-    DRAMPower/util/bus_types.h
-    DRAMPower/util/cli_architecture_config.h
-    DRAMPower/util/clock.h
-    DRAMPower/util/command_counter.h
-    DRAMPower/util/cycle_stats.h
-    DRAMPower/util/databus.h
-    DRAMPower/util/databus_presets.h
-    DRAMPower/util/databus_types.h
-    DRAMPower/util/dbi.h
-    DRAMPower/util/dynamic_bitset.h
-    DRAMPower/util/extension_base.h
+
     DRAMPower/util/extension_manager.h
-    DRAMPower/util/extension_manager_static.h
     DRAMPower/util/extensions.h
-    DRAMPower/util/pending_stats.h
-    DRAMPower/util/pin.h
-    DRAMPower/util/pin_types.h
-    DRAMPower/util/sub_bitset.h
+    
+    DRAMPower/memspec/MemSpec.h
+
+    DRAMPower/memspec/MemSpecDDR4.h
+    DRAMPower/standards/ddr4/DDR4.h
+    
+    DRAMPower/memspec/MemSpecDDR5.h
+    DRAMPower/standards/ddr5/DDR5.h
+    
+    DRAMPower/memspec/MemSpecLPDDR4.h
+    DRAMPower/standards/lpddr4/LPDDR4.h
+    
+    DRAMPower/memspec/MemSpecLPDDR5.h
+    DRAMPower/standards/lpddr5/LPDDR5.h
+    
+    DRAMPower/util/Serialize.h
+    DRAMPower/util/Deserialize.h
 )
 
 target_include_directories(DRAMPower PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/DRAMPower/DRAMPower/dram/dram_base.h
+++ b/src/DRAMPower/DRAMPower/dram/dram_base.h
@@ -2,7 +2,6 @@
 #define DRAMPOWER_DRAM_DRAM_BASE_H
 
 #include <DRAMPower/command/Command.h>
-#include <DRAMPower/command/Pattern.h>
 
 #include <DRAMPower/data/energy.h>
 #include <DRAMPower/data/stats.h>
@@ -38,8 +37,6 @@ public:
     using commandEnum_t = CommandEnum;
     using commandCount_t = std::vector<std::size_t>;
     using commandRouter_t = Router<commandEnum_t>;
-    // PatternHandler
-    using patternHandler_t = PatternHandler<commandEnum_t>;
     // ImplicitCommandHandler
     using ImplicitCommandHandler_t = ImplicitCommandHandler;
     using implicitCommandInserter_t = typename ImplicitCommandHandler::Inserter_t;


### PR DESCRIPTION
Implementiere install support für DRAMPower für bessere Integration zB. mit gem5.
Hier gibt es noch TODOs:
- [x] Es sollte nur die Header der Public API von DRAMPower installiert werden. Welche Header bilden die Public API?