### PR TITLE
Refactor energy calculation methods across all standards

### DIFF
--- a/src/DRAMPower/DRAMPower/standards/ddr4/core_calculation_DDR4.cpp
+++ b/src/DRAMPower/DRAMPower/standards/ddr4/core_calculation_DDR4.cpp
@@ -14,8 +14,8 @@ namespace DRAMPower {
 		return VDD * I_rho * T_BG_act;
 	}
 
-	inline double Calculation_DDR4::E_BG_act_star(std::size_t B, double VDD, double IDD3_N, double I_rho, double T_BG_act_star) const {
-        return VDD * (1.0 / B) * (IDD3_N - I_rho) * T_BG_act_star;
+	inline double Calculation_DDR4::E_BG_act_star(double VDD, double I_1, double I_rho, double T_BG_act_star) const {
+        return VDD * (I_1 - I_rho) * T_BG_act_star;
 	}
 
     inline double Calculation_DDR4::E_pre(double VDD, double IBeta, double IDD2_N, double t_RP, uint64_t N_pre) const {
@@ -26,16 +26,16 @@ namespace DRAMPower {
 		return VDD * (I_theta - I_1) * t_RAS * N_act;
 	}
 
-	inline double Calculation_DDR4::E_RD(double VDD, double IDD4_R, double IDD3_N, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_RD) const {
-        return VDD * (IDD4_R - IDD3_N) * (double(BL) / DR) * t_CK * N_RD;
+	inline double Calculation_DDR4::E_RD(double VDD, double IDD4_R, double I_B, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_RD) const {
+        return VDD * (IDD4_R - I_B) * (double(BL) / DR) * t_CK * N_RD;
 	}
 
-	inline double Calculation_DDR4::E_WR(double VDD, double IDD4_W, double IDD3_N, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_WR) const {
-		return VDD * (IDD4_W - IDD3_N) * (BL / DR) * t_CK * N_WR;
+	inline double Calculation_DDR4::E_WR(double VDD, double IDD4_W, double I_B, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_WR) const {
+		return VDD * (IDD4_W - I_B) * (BL / DR) * t_CK * N_WR;
 	}
 
-	inline double Calculation_DDR4::E_ref_ab(std::size_t B, double VDD, double IDD5B, double IDD3_N, double tRFC, uint64_t N_REF) const {
-        return (1.0 / B) * VDD * (IDD5B - IDD3_N) * tRFC * N_REF;
+	inline double Calculation_DDR4::E_ref_ab(std::size_t B, double VDD, double IDD5B, double I_B, double tRFC, uint64_t N_REF) const {
+        return (1.0 / B) * VDD * (IDD5B - I_B) * tRFC * N_REF;
 	}
 
 	energy_t Calculation_DDR4::calcEnergy(const SimulationStats &stats) const {
@@ -57,7 +57,7 @@ namespace DRAMPower {
                 auto VXX = m_memSpec.memPowerSpec[vd].vXX;
                 auto IXX_0 = m_memSpec.memPowerSpec[vd].iXX0;
                 auto IXX2N = m_memSpec.memPowerSpec[vd].iXX2N;
-                auto IXX3N = m_memSpec.memPowerSpec[vd].iXX3N;
+                auto I_B = m_memSpec.memPowerSpec[vd].iXX3N;
                 auto IXX2P = m_memSpec.memPowerSpec[vd].iXX2P;
                 auto IXX3P = m_memSpec.memPowerSpec[vd].iXX3P;
                 auto IXX4R = m_memSpec.memPowerSpec[vd].iXX4R;
@@ -66,9 +66,9 @@ namespace DRAMPower {
                 auto IXX6N = m_memSpec.memPowerSpec[vd].iXX6N;
                 auto IBeta = m_memSpec.memPowerSpec[vd].iBeta;
 
-                auto I_rho = rho * (IXX3N - IXX2N) + IXX2N;
+                auto I_rho = rho * (I_B - IXX2N) + IXX2N;
                 auto I_theta = (IXX_0 * (t_RP + t_RAS) - IBeta * t_RP) * (1 / t_RAS);
-                auto I_1 = (1.0 / B) * (IXX3N + (B - 1) * (rho * (IXX3N - IXX2N) + IXX2N));
+                auto I_1 = (1.0 / B) * (I_B + (B - 1) * I_rho);
 
                 size_t energy_offset = 0;
                 size_t bank_offset = 0;
@@ -88,24 +88,24 @@ namespace DRAMPower {
                             energy.bank_energy[energy_offset + b].E_pre +=
                                 E_pre(VXX, IBeta, IXX2N, t_RP, bank.counter.pre);
                             energy.bank_energy[energy_offset + b].E_bg_act +=
-                                E_BG_act_star(B, VXX, IXX3N, I_rho,
+                                E_BG_act_star(VXX, I_1, I_rho,
                                     stats.bank[bank_offset + b].cycles.activeTime() * t_CK);
                             energy.bank_energy[energy_offset + b].E_bg_pre +=
                                 E_BG_pre(B, VXX, IXX2N, stats.rank_total[r].cycles.pre * t_CK);
                             energy.bank_energy[energy_offset + b].E_RD +=
-                                E_RD(VXX, IXX4R, IXX3N, t_CK, BL, DR, bank.counter.reads);
+                                E_RD(VXX, IXX4R, I_B, t_CK, BL, DR, bank.counter.reads);
                             energy.bank_energy[energy_offset + b].E_WR +=
-                                E_WR(VXX, IXX4W, IXX3N, t_CK, BL, DR, bank.counter.writes);
+                                E_WR(VXX, IXX4W, I_B, t_CK, BL, DR, bank.counter.writes);
                             energy.bank_energy[energy_offset + b].E_RDA +=
-                                E_RD(VXX, IXX4R, IXX3N, t_CK, BL, DR, bank.counter.readAuto);
+                                E_RD(VXX, IXX4R, I_B, t_CK, BL, DR, bank.counter.readAuto);
                             energy.bank_energy[energy_offset + b].E_WRA +=
-                                E_WR(VXX, IXX4W, IXX3N, t_CK, BL, DR, bank.counter.writeAuto);
+                                E_WR(VXX, IXX4W, I_B, t_CK, BL, DR, bank.counter.writeAuto);
                             energy.bank_energy[energy_offset + b].E_pre_RDA +=
                                 E_pre(VXX, IBeta, IXX2N, t_RP, bank.counter.readAuto);
                             energy.bank_energy[energy_offset + b].E_pre_WRA +=
                                 E_pre(VXX, IBeta, IXX2N, t_RP, bank.counter.writeAuto);
                             energy.bank_energy[energy_offset + b].E_ref_AB +=
-                                E_ref_ab(B, VXX, IXX5X, IXX3N, t_RFC, bank.counter.refAllBank);
+                                E_ref_ab(B, VXX, IXX5X, I_B, t_RFC, bank.counter.refAllBank);
                         }
                     }
 

--- a/src/DRAMPower/DRAMPower/standards/ddr4/core_calculation_DDR4.h
+++ b/src/DRAMPower/DRAMPower/standards/ddr4/core_calculation_DDR4.h
@@ -24,11 +24,11 @@ private:
 	inline double E_act(double VDD, double I_theta, double I_1, double t_RAS, uint64_t N_act) const;
 	inline double E_pre(double VDD, double IBeta, double IDD2_N, double t_RP, uint64_t N_pre) const;
 	inline double E_BG_pre(std::size_t B, double VDD, double IDD2_N, double T_BG_pre) const;
-	inline double E_BG_act_star(std::size_t B, double VDD, double IDD3_N, double I_rho, double T_BG_act_star) const;
+	inline double E_BG_act_star(double VDD, double I_1, double I_rho, double T_BG_act_star) const;
 	inline double E_BG_act_shared(double VDD, double I_rho, double T_BG_act) const;
-	inline double E_RD(double VDD, double IDD4_R, double IDD3_N, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_RD) const;
-	inline double E_WR(double VDD, double IDD4_W, double IDD3_N, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_WR) const;
-	inline double E_ref_ab(std::size_t B, double VDD, double IDD5B, double IDD3_N, double tRFC, uint64_t N_REF) const;
+	inline double E_RD(double VDD, double IDD4_R, double I_B, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_RD) const;
+	inline double E_WR(double VDD, double IDD4_W, double I_B, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_WR) const;
+	inline double E_ref_ab(std::size_t B, double VDD, double IDD5B, double I_B, double tRFC, uint64_t N_REF) const;
 	
 public:
 	energy_t calcEnergy(const SimulationStats &stats) const;

--- a/src/DRAMPower/DRAMPower/standards/ddr5/core_calculation_DDR5.cpp
+++ b/src/DRAMPower/DRAMPower/standards/ddr5/core_calculation_DDR5.cpp
@@ -17,8 +17,8 @@ namespace DRAMPower {
     }
 
     double
-    Calculation_DDR5::E_BG_act_star(std::size_t B, double VDD, double IDD3_N, double I_rho, double T_BG_act_star) const {
-        return VDD * (1.0 / B) * (IDD3_N - I_rho) * T_BG_act_star;
+    Calculation_DDR5::E_BG_act_star(double VDD, double I_1, double I_rho, double T_BG_act_star) const {
+        return VDD * (I_1 - I_rho) * T_BG_act_star;
     }
 
     double Calculation_DDR5::E_pre(double VDD, double IBeta, double IDD2_N, double t_RP, uint64_t N_pre) const {
@@ -29,19 +29,19 @@ namespace DRAMPower {
         return VDD * (I_theta - I_1) * t_RAS * N_act;
     }
 
-    double Calculation_DDR5::E_RD(double VDD, double IDD4_R, double IDD3_N, double t_CK, std::size_t BL, std::size_t DR,
+    double Calculation_DDR5::E_RD(double VDD, double IDD4_R, double I_B, double t_CK, std::size_t BL, std::size_t DR,
                                   uint64_t N_RD) const {
-        return VDD * (IDD4_R - IDD3_N) * (double(BL) / DR) * t_CK * N_RD;
+        return VDD * (IDD4_R - I_B) * (double(BL) / DR) * t_CK * N_RD;
     }
 
-    double Calculation_DDR5::E_WR(double VDD, double IDD4_W, double IDD3_N, double t_CK, std::size_t BL, std::size_t DR,
+    double Calculation_DDR5::E_WR(double VDD, double IDD4_W, double I_B, double t_CK, std::size_t BL, std::size_t DR,
                                   uint64_t N_WR) const {
-        return VDD * (IDD4_W - IDD3_N) * (BL / DR) * t_CK * N_WR;
+        return VDD * (IDD4_W - I_B) * (BL / DR) * t_CK * N_WR;
     }
 
     double
-    Calculation_DDR5::E_ref_ab(std::size_t B, double VDD, double IDD5B, double IDD3_N, double tRFC, uint64_t N_REF) const {
-        return (1.0 / B) * VDD * (IDD5B - IDD3_N) * tRFC * N_REF;
+    Calculation_DDR5::E_ref_ab(std::size_t B, double VDD, double IDD5B, double I_B, double tRFC, uint64_t N_REF) const {
+        return (1.0 / B) * VDD * (IDD5B - I_B) * tRFC * N_REF;
     }
 
     double Calculation_DDR5::E_ref_sb(double VDD, double IDD5C, double I_BG, double tRFCsb, std::size_t BG,
@@ -68,7 +68,7 @@ namespace DRAMPower {
             auto VXX = m_memSpec.memPowerSpec[vd].vXX;
             auto IXX_0 = m_memSpec.memPowerSpec[vd].iXX0;
             auto IXX2N = m_memSpec.memPowerSpec[vd].iXX2N;
-            auto IXX3N = m_memSpec.memPowerSpec[vd].iXX3N;
+            auto I_B = m_memSpec.memPowerSpec[vd].iXX3N;
             auto IXX2P = m_memSpec.memPowerSpec[vd].iXX2P;
             auto IXX3P = m_memSpec.memPowerSpec[vd].iXX3P;
             auto IXX4R = m_memSpec.memPowerSpec[vd].iXX4R;
@@ -78,9 +78,9 @@ namespace DRAMPower {
             auto IXX6N = m_memSpec.memPowerSpec[vd].iXX6N;
             auto IBeta = m_memSpec.memPowerSpec[vd].iBeta;
 
-            auto I_rho = rho * (IXX3N - IXX2N) + IXX2N;
+            auto I_rho = rho * (I_B - IXX2N) + IXX2N;
             auto I_theta = (IXX_0 * (t_RP + t_RAS) - IBeta * t_RP) * (1 / t_RAS);
-            auto I_1 = (1.0 / B) * (IXX3N + (B - 1) * (rho * (IXX3N - IXX2N) + IXX2N));
+            auto I_1 = (1.0 / B) * (I_B + (B - 1) * I_rho);
             auto I_BG = I_rho + (I_1 - I_rho) * BG;
 
             size_t energy_offset = 0;
@@ -99,24 +99,24 @@ namespace DRAMPower {
                         energy.bank_energy[energy_offset + b].E_pre +=
                             E_pre(VXX, IBeta, IXX2N, t_RP, bank.counter.pre);
                         energy.bank_energy[energy_offset + b].E_bg_act +=
-                            E_BG_act_star(B, VXX, IXX3N, I_rho,
+                            E_BG_act_star(VXX, I_1, I_rho,
                                         stats.bank[bank_offset + b].cycles.activeTime() * t_CK);
                         energy.bank_energy[energy_offset + b].E_bg_pre +=
                             E_BG_pre(B, VXX, IXX2N, stats.rank_total[i].cycles.pre * t_CK);
                         energy.bank_energy[energy_offset + b].E_RD +=
-                            E_RD(VXX, IXX4R, IXX3N, t_CK, BL, DR, bank.counter.reads);
+                            E_RD(VXX, IXX4R, I_B, t_CK, BL, DR, bank.counter.reads);
                         energy.bank_energy[energy_offset + b].E_WR +=
-                            E_WR(VXX, IXX4W, IXX3N, t_CK, BL, DR, bank.counter.writes);
+                            E_WR(VXX, IXX4W, I_B, t_CK, BL, DR, bank.counter.writes);
                         energy.bank_energy[energy_offset + b].E_RDA +=
-                            E_RD(VXX, IXX4R, IXX3N, t_CK, BL, DR, bank.counter.readAuto);
+                            E_RD(VXX, IXX4R, I_B, t_CK, BL, DR, bank.counter.readAuto);
                         energy.bank_energy[energy_offset + b].E_WRA +=
-                            E_WR(VXX, IXX4W, IXX3N, t_CK, BL, DR, bank.counter.writeAuto);
+                            E_WR(VXX, IXX4W, I_B, t_CK, BL, DR, bank.counter.writeAuto);
                         energy.bank_energy[energy_offset + b].E_pre_RDA +=
                             E_pre(VXX, IBeta, IXX2N, t_RP, bank.counter.readAuto);
                         energy.bank_energy[energy_offset + b].E_pre_WRA +=
                             E_pre(VXX, IBeta, IXX2N, t_RP, bank.counter.writeAuto);
                         energy.bank_energy[energy_offset + b].E_ref_AB +=
-                            E_ref_ab(B, VXX, IXX5X, IXX3N, t_RFC, bank.counter.refAllBank);
+                            E_ref_ab(B, VXX, IXX5X, I_B, t_RFC, bank.counter.refAllBank);
                         energy.bank_energy[energy_offset + b].E_ref_SB +=
                             E_ref_sb(VXX, IXX5C, I_BG, t_RFCsb, BG, bank.counter.refSameBank);
                     }

--- a/src/DRAMPower/DRAMPower/standards/ddr5/core_calculation_DDR5.h
+++ b/src/DRAMPower/DRAMPower/standards/ddr5/core_calculation_DDR5.h
@@ -24,11 +24,11 @@ private:
     inline double E_act(double VDD, double I_theta, double I_1, double t_RAS, uint64_t N_act) const;
     inline double E_pre(double VDD, double IBeta, double IDD2_N, double t_RP, uint64_t N_pre) const;
     inline double E_BG_pre(std::size_t B, double VDD, double IDD2_N, double T_BG_pre) const;
-    inline double E_BG_act_star(std::size_t B, double VDD, double IDD3_N, double I_rho, double T_BG_act_star) const;
+    inline double E_BG_act_star(double VDD, double I_1, double I_rho, double T_BG_act_star) const;
     inline double E_BG_act_shared(double VDD, double I_rho, double T_BG_act) const;
-    inline double E_RD(double VDD, double IDD4_R, double IDD3_N, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_RD) const;
-    inline double E_WR(double VDD, double IDD4_W, double IDD3_N, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_WR) const;
-    inline double E_ref_ab(std::size_t B, double VDD, double IDD5B, double IDD3_N, double tRFC, uint64_t N_REF) const;
+    inline double E_RD(double VDD, double IDD4_R, double I_B, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_RD) const;
+    inline double E_WR(double VDD, double IDD4_W, double I_B, double t_CK, std::size_t BL, std::size_t DR, uint64_t N_WR) const;
+    inline double E_ref_ab(std::size_t B, double VDD, double IDD5B, double I_B, double tRFC, uint64_t N_REF) const;
     inline double E_ref_sb(double VDD, double IDD5C, double I_BG, double tRFC, std::size_t BG, uint64_t N_SB_REF) const;
 
 public:

--- a/src/DRAMPower/DRAMPower/standards/lpddr4/core_calculation_LPDDR4.cpp
+++ b/src/DRAMPower/DRAMPower/standards/lpddr4/core_calculation_LPDDR4.cpp
@@ -12,36 +12,36 @@ namespace DRAMPower {
         return VDD * (IBeta - IDD2N) * t_RP * N_pre;
     }
 
-    double Calculation_LPDDR4::E_act(double VDD, double I_theta, double IDD3N, double t_RAS, uint64_t N_act) const {
-        return VDD * (I_theta - IDD3N) * t_RAS * N_act;
+    double Calculation_LPDDR4::E_act(double VDD, double I_theta, double I_1, double t_RAS, uint64_t N_act) const {
+        return VDD * (I_theta - I_1) * t_RAS * N_act;
     }
 
     double Calculation_LPDDR4::E_BG_pre(std::size_t B, double VDD, double IDD2N, double T_BG_pre) const {
         return (1.0 / B) * VDD * IDD2N * T_BG_pre;
     }
 
-    double Calculation_LPDDR4::E_BG_act_star(std::size_t B, double VDD, double IDD3N, double I_p, double T_BG_act_star) const {
-        return VDD * (1.0 / B) * (IDD3N - I_p) * T_BG_act_star;
+    double Calculation_LPDDR4::E_BG_act_star(double VDD, double I_1, double I_rho, double T_BG_act_star) const {
+        return VDD * (I_1 - I_rho) * T_BG_act_star;
     }
 
-    double Calculation_LPDDR4::E_BG_act_shared(double VDD, double I_p, double T_bg_act) const {
-        return VDD * I_p * T_bg_act;
+    double Calculation_LPDDR4::E_BG_act_shared(double VDD, double I_rho, double T_bg_act) const {
+        return VDD * I_rho * T_bg_act;
     }
 
-    double Calculation_LPDDR4::E_RD(double VDD, double IDD4_R, double IDD3N, std::size_t BL, std::size_t DR, double t_CK, uint64_t N_RD) const {
-        return VDD * (IDD4_R - IDD3N) * (BL / DR) * t_CK * N_RD;
+    double Calculation_LPDDR4::E_RD(double VDD, double IDD4_R, double I_1, std::size_t BL, std::size_t DR, double t_CK, uint64_t N_RD) const {
+        return VDD * (IDD4_R - I_1) * (BL / DR) * t_CK * N_RD;
     }
 
-    double Calculation_LPDDR4::E_WR(double VDD, double IDD4_W, double IDD3N, std::size_t BL, std::size_t DR, double t_CK, uint64_t N_WR) const {
-        return VDD * (IDD4_W - IDD3N) * (BL / DR) * t_CK * N_WR;
+    double Calculation_LPDDR4::E_WR(double VDD, double IDD4_W, double I_1, std::size_t BL, std::size_t DR, double t_CK, uint64_t N_WR) const {
+        return VDD * (IDD4_W - I_1) * (BL / DR) * t_CK * N_WR;
     }
 
-    double Calculation_LPDDR4::E_ref_ab(std::size_t B, double VDD, double IDD5, double approx_IDD3N, double tRFC, uint64_t N_REF) const {
-        return (1.0 / B) * VDD * (IDD5 - approx_IDD3N) * tRFC * N_REF;
+    double Calculation_LPDDR4::E_ref_ab(std::size_t B, double VDD, double IDD5, double I_B, double tRFC, uint64_t N_REF) const {
+        return (1.0 / B) * VDD * (IDD5 - I_B) * tRFC * N_REF;
     }
 
-    double Calculation_LPDDR4::E_ref_pb(double VDD, double IDD5PB_B, double IDD3N, double tRFCPB, uint64_t N_PB_REF) const {
-        return VDD * (IDD5PB_B - IDD3N) * tRFCPB * N_PB_REF;
+    double Calculation_LPDDR4::E_ref_pb(double VDD, double IDD5PB_B, double I_1, double tRFCPB, uint64_t N_PB_REF) const {
+        return VDD * (IDD5PB_B - I_1) * tRFCPB * N_PB_REF;
     }
 
     energy_t Calculation_LPDDR4::calcEnergy(const SimulationStats &stats) const {
@@ -63,7 +63,7 @@ namespace DRAMPower {
             auto VDD = m_memSpec.memPowerSpec[vd].vDDX;
             auto IDD_0 = m_memSpec.memPowerSpec[vd].iDD0X;
             auto IDD2N = m_memSpec.memPowerSpec[vd].iDD2NX;
-            auto IDD3N = m_memSpec.memPowerSpec[vd].iDD3NX;
+            auto I_1 = m_memSpec.memPowerSpec[vd].iDD3NX;
             auto IDD2P = m_memSpec.memPowerSpec[vd].iDD2PX;
             auto IDD3P = m_memSpec.memPowerSpec[vd].iDD3PX;
             auto IDD4R = m_memSpec.memPowerSpec[vd].iDD4RX;
@@ -73,11 +73,13 @@ namespace DRAMPower {
             auto IDD6 = m_memSpec.memPowerSpec[vd].iDD6X;
             auto IBeta = m_memSpec.memPowerSpec[vd].iBeta;
 
-            auto I_rho = rho * (IDD3N - IDD2N) + IDD2N;
+            auto t1 = B * rho;
+            auto t2 = 1 - rho;
+            auto I_rho = (t1 * I_1 + t2 * IDD2N) / (t1 + t2);
             auto I_theta = (IDD_0 * (t_RP + t_RAS) - IBeta * t_RP) * (1 / t_RAS);
             auto IDD5PB_B =
                 (IDD5PB * (t_REFI / 8) - IDD2N * ((t_REFI / 8) - t_RFCPB)) * (1.0 / t_RFCPB);
-            auto approx_IDD3N = I_rho + B * (IDD3N - I_rho);
+            auto I_B = I_rho + B * (I_1 - I_rho);
 
             size_t energy_offset = 0;
             size_t bank_offset = 0;
@@ -90,30 +92,30 @@ namespace DRAMPower {
                         const auto &bank = stats.bank[bank_offset + b];
 
                         energy.bank_energy[energy_offset + b].E_act +=
-                            E_act(VDD, I_theta, IDD3N, t_RAS, bank.counter.act);
+                            E_act(VDD, I_theta, I_1, t_RAS, bank.counter.act);
                         energy.bank_energy[energy_offset + b].E_pre +=
                             E_pre(VDD, IBeta, IDD2N, t_RP, bank.counter.pre);
                         energy.bank_energy[energy_offset + b].E_bg_act +=
-                            E_BG_act_star(B, VDD, approx_IDD3N, I_rho,
+                            E_BG_act_star(VDD, I_1, I_rho,
                                         stats.bank[bank_offset + b].cycles.activeTime() * t_CK);
                         energy.bank_energy[energy_offset + b].E_bg_pre +=
                             E_BG_pre(B, VDD, IDD2N, stats.rank_total[i].cycles.pre * t_CK);
                         energy.bank_energy[energy_offset + b].E_RD +=
-                            E_RD(VDD, IDD4R, IDD3N, BL, DR, t_CK, bank.counter.reads);
+                            E_RD(VDD, IDD4R, I_1, BL, DR, t_CK, bank.counter.reads);
                         energy.bank_energy[energy_offset + b].E_WR +=
-                            E_WR(VDD, IDD4W, IDD3N, BL, DR, t_CK, bank.counter.writes);
+                            E_WR(VDD, IDD4W, I_1, BL, DR, t_CK, bank.counter.writes);
                         energy.bank_energy[energy_offset + b].E_RDA +=
-                            E_RD(VDD, IDD4R, IDD3N, BL, DR, t_CK, bank.counter.readAuto);
+                            E_RD(VDD, IDD4R, I_1, BL, DR, t_CK, bank.counter.readAuto);
                         energy.bank_energy[energy_offset + b].E_WRA +=
-                            E_WR(VDD, IDD4W, IDD3N, BL, DR, t_CK, bank.counter.writeAuto);
+                            E_WR(VDD, IDD4W, I_1, BL, DR, t_CK, bank.counter.writeAuto);
                         energy.bank_energy[energy_offset + b].E_pre_RDA +=
                             E_pre(VDD, IBeta, IDD2N, t_RP, bank.counter.readAuto);
                         energy.bank_energy[energy_offset + b].E_pre_WRA +=
                             E_pre(VDD, IBeta, IDD2N, t_RP, bank.counter.writeAuto);
                         energy.bank_energy[energy_offset + b].E_ref_AB +=
-                            E_ref_ab(B, VDD, IDD5, approx_IDD3N, t_RFC, bank.counter.refAllBank);
+                            E_ref_ab(B, VDD, IDD5, I_B, t_RFC, bank.counter.refAllBank);
                         energy.bank_energy[energy_offset + b].E_ref_PB +=
-                            E_ref_pb(VDD, IDD5PB_B, IDD3N, t_RFCPB, bank.counter.refPerBank);
+                            E_ref_pb(VDD, IDD5PB_B, I_1, t_RFCPB, bank.counter.refPerBank);
                     }   
                 }
 

--- a/src/DRAMPower/DRAMPower/standards/lpddr4/core_calculation_LPDDR4.h
+++ b/src/DRAMPower/DRAMPower/standards/lpddr4/core_calculation_LPDDR4.h
@@ -21,15 +21,15 @@ public:
     Calculation_LPDDR4(const MemSpecLPDDR4 &memSpec);
 
 private:
-    double E_act(double VDD, double I_theta, double IDD3N, double tRAS, uint64_t N_act) const;
+    double E_act(double VDD, double I_theta, double I_1, double tRAS, uint64_t N_act) const;
     double E_pre(double VDD, double IBeta, double IDD2N, double tRP, uint64_t N_pre) const;
     double E_BG_pre(std::size_t B, double VDD, double IDD2N, double T_BG_pre) const;
-    double E_BG_act_star(std::size_t B, double VDD, double IDD3N, double I_rho, double T_BG_act_star) const;
+    double E_BG_act_star(double VDD, double I_1, double I_rho, double T_BG_act_star) const;
     double E_BG_act_shared(double VDD, double I_rho, double T_bg_act) const;
-	double E_RD(double VDD, double IDD4R, double IDD3N, std::size_t BL, std::size_t DR, double t_CK, uint64_t N_RD) const;
-	double E_WR(double VDD, double IDD4W, double IDD3N, std::size_t BL, std::size_t DR, double t_CK, uint64_t N_WR) const;
-    double E_ref_ab(std::size_t B, double VDD, double IDD5B, double approx_IDD3N, double tRFC, uint64_t N_REF) const;
-    double E_ref_pb(double VDD, double IDD5PB_B, double IDD3N, double tRFCPB, uint64_t N_PB_REF) const;
+	double E_RD(double VDD, double IDD4R, double I_1, std::size_t BL, std::size_t DR, double t_CK, uint64_t N_RD) const;
+	double E_WR(double VDD, double IDD4W, double I_1, std::size_t BL, std::size_t DR, double t_CK, uint64_t N_WR) const;
+    double E_ref_ab(std::size_t B, double VDD, double IDD5B, double I_B, double tRFC, uint64_t N_REF) const;
+    double E_ref_pb(double VDD, double IDD5PB_B, double I_1, double tRFCPB, uint64_t N_PB_REF) const;
 
 public:
 	energy_t calcEnergy(const SimulationStats &stats) const;

--- a/src/DRAMPower/DRAMPower/standards/lpddr5/core_calculation_LPDDR5.cpp
+++ b/src/DRAMPower/DRAMPower/standards/lpddr5/core_calculation_LPDDR5.cpp
@@ -21,12 +21,12 @@ namespace DRAMPower {
         return (1.0 / B) * VDD * IDD2_N * T_BG_pre;
     }
 
-    double Calculation_LPDDR5::E_BG_act_star(std::size_t B, double VDD, double IDD3_N, double I_p, double T_BG_act_star) const {
-        return VDD * (1.0 / B) * (IDD3_N - I_p) * T_BG_act_star;
+    double Calculation_LPDDR5::E_BG_act_star(double VDD, double I_1, double I_rho, double T_BG_act_star) const {
+        return VDD * (I_1 - I_rho) * T_BG_act_star;
     }
 
-    double Calculation_LPDDR5::E_BG_act_shared(double VDD, double I_p, double T_bg_act) const {
-        return VDD * I_p * T_bg_act;
+    double Calculation_LPDDR5::E_BG_act_shared(double VDD, double I_rho, double T_bg_act) const {
+        return VDD * I_rho * T_bg_act;
     }
 
     double Calculation_LPDDR5::E_RD(double VDD, double IDD4_R, double I_i, std::size_t BL, std::size_t DR, double t_WCK, uint64_t N_RD) const {
@@ -69,7 +69,7 @@ namespace DRAMPower {
             auto VDD = m_memSpec.memPowerSpec[vd].vDDX;
             auto IDD_0 = m_memSpec.memPowerSpec[vd].iDD0X;
             auto IDD2N = m_memSpec.memPowerSpec[vd].iDD2NX;
-            auto IDD3N = m_memSpec.memPowerSpec[vd].iDD3NX;
+            auto I_1 = m_memSpec.memPowerSpec[vd].iDD3NX;
             auto IDD2P = m_memSpec.memPowerSpec[vd].iDD2PX;
             auto IDD3P = m_memSpec.memPowerSpec[vd].iDD3PX;
             auto IDD4R = m_memSpec.memPowerSpec[vd].iDD4RX;
@@ -80,12 +80,14 @@ namespace DRAMPower {
             auto IDD6DS = m_memSpec.memPowerSpec[vd].iDD6DSX;
             auto IBeta = m_memSpec.memPowerSpec[vd].iBeta;
 
-            auto I_rho = rho * (IDD3N - IDD2N) + IDD2N;
-            auto I_2 = IDD3N + (IDD3N - I_rho);
+            auto t1 = B * rho;
+            auto t2 = 1 - rho;
+            auto I_rho = (t1 * I_1 + t2 * IDD2N) / (t1 + t2);
+            auto I_B = I_rho + B * (I_1 - I_rho);
+            auto I_2 = I_1 + (I_1 - I_rho);
             auto I_theta = (IDD_0 * (t_RP + t_RAS) - IBeta * t_RP) * (1 / t_RAS);
             auto IDD5PB_B =
                 (IDD5PB * (t_REFI / 8) - IDD2N * ((t_REFI / 8) - t_RFCPB)) * (1.0 / t_RFCPB);
-            auto approx_IDD3N = I_rho + B * (IDD3N - I_rho);
 
             size_t energy_offset = 0;
             size_t bank_offset = 0;
@@ -98,11 +100,11 @@ namespace DRAMPower {
                         const auto &bank = stats.bank[bank_offset + b];
 
                         energy.bank_energy[energy_offset + b].E_act +=
-                            E_act(VDD, I_theta, IDD3N, t_RAS, bank.counter.act);
+                            E_act(VDD, I_theta, I_1, t_RAS, bank.counter.act);
                         energy.bank_energy[energy_offset + b].E_pre +=
                             E_pre(VDD, IBeta, IDD2N, t_RP, bank.counter.pre);
                         energy.bank_energy[energy_offset + b].E_bg_act +=
-                            E_BG_act_star(B, VDD, approx_IDD3N, I_rho,
+                            E_BG_act_star(VDD, I_1, I_rho,
                                         stats.bank[bank_offset + b].cycles.activeTime() * t_CK);
                         energy.bank_energy[energy_offset + b].E_bg_pre +=
                             E_BG_pre(B, VDD, IDD2N, stats.rank_total[i].cycles.pre * t_CK);
@@ -117,22 +119,22 @@ namespace DRAMPower {
                                 E_WR(VDD, IDD4W, I_2, BL, DR, t_WCK, bank.counter.writeAuto);
                         } else {
                             energy.bank_energy[energy_offset + b].E_RD +=
-                                E_RD(VDD, IDD4R, IDD3N, BL, DR, t_WCK, bank.counter.reads);
+                                E_RD(VDD, IDD4R, I_1, BL, DR, t_WCK, bank.counter.reads);
                             energy.bank_energy[energy_offset + b].E_WR +=
-                                E_WR(VDD, IDD4W, IDD3N, BL, DR, t_WCK, bank.counter.writes);
+                                E_WR(VDD, IDD4W, I_1, BL, DR, t_WCK, bank.counter.writes);
                             energy.bank_energy[energy_offset + b].E_RDA +=
-                                E_RD(VDD, IDD4R, IDD3N, BL, DR, t_WCK, bank.counter.readAuto);
+                                E_RD(VDD, IDD4R, I_1, BL, DR, t_WCK, bank.counter.readAuto);
                             energy.bank_energy[energy_offset + b].E_WRA +=
-                                E_WR(VDD, IDD4W, IDD3N, BL, DR, t_WCK, bank.counter.writeAuto);
+                                E_WR(VDD, IDD4W, I_1, BL, DR, t_WCK, bank.counter.writeAuto);
                         }
                         energy.bank_energy[energy_offset + b].E_pre_RDA +=
                             E_pre(VDD, IBeta, IDD2N, t_RP, bank.counter.readAuto);
                         energy.bank_energy[energy_offset + b].E_pre_WRA +=
                             E_pre(VDD, IBeta, IDD2N, t_RP, bank.counter.writeAuto);
                         energy.bank_energy[energy_offset + b].E_ref_AB +=
-                            E_ref_ab(B, VDD, IDD5, approx_IDD3N, t_RFC, bank.counter.refAllBank);
+                            E_ref_ab(B, VDD, IDD5, I_B, t_RFC, bank.counter.refAllBank);
                         energy.bank_energy[energy_offset + b].E_ref_PB +=
-                            E_ref_pb(VDD, IDD5PB_B, IDD3N, t_RFCPB, bank.counter.refPerBank);
+                            E_ref_pb(VDD, IDD5PB_B, I_1, t_RFCPB, bank.counter.refPerBank);
                         energy.bank_energy[energy_offset + b].E_ref_2B +=
                             E_ref_p2b(VDD, IDD5PB_B, I_2, t_RFCPB, bank.counter.refPerTwoBanks);
                     }

--- a/src/DRAMPower/DRAMPower/standards/lpddr5/core_calculation_LPDDR5.h
+++ b/src/DRAMPower/DRAMPower/standards/lpddr5/core_calculation_LPDDR5.h
@@ -24,8 +24,8 @@ namespace DRAMPower
         double E_act(double VDD, double I_theta, double I_1, double t_RAS, uint64_t N_act) const;
         double E_pre(double VDD, double IBeta, double IDD2_N, double t_RP, uint64_t N_pre) const;
         double E_BG_pre(std::size_t B, double VDD, double IDD2_N, double T_BG_pre) const;
-        double E_BG_act_star(std::size_t B, double VDD, double IDD3_N, double I_p, double T_BG_act_star) const;
-        double E_BG_act_shared(double VDD, double I_p, double T_bg_act) const;
+        double E_BG_act_star(double VDD, double I_1, double I_rho, double T_BG_act_star) const;
+        double E_BG_act_shared(double VDD, double I_rho, double T_bg_act) const;
         double E_RD(double VDD, double IDD4_R, double I_i, std::size_t BL, std::size_t DR, double t_WCK, uint64_t N_RD) const;
         double E_WR(double VDD, double IDD4_W, double I_i, std::size_t BL, std::size_t DR, double t_WCK, uint64_t N_WR) const;
         double E_ref_ab(std::size_t B, double VDD, double IDD5B, double IDD3_N, double tRFC, uint64_t N_REF) const;

--- a/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_11.cpp
+++ b/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_11.cpp
@@ -167,16 +167,16 @@ TEST_F(DramPowerTest_LPDDR4_11, CalcEnergy)
 	ASSERT_EQ(std::round(energy.bank_energy[6].E_pre*1e12), 0);
 	ASSERT_EQ(std::round(energy.bank_energy[7].E_pre*1e12), 560);
 
-	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 480);
-	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 240);
-	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 240);
-	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 240);
+	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 144);
+	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 72);
+	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 72);
+	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 72);
 	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 0);
 	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 0);
-	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 80);
-	ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 240);
-	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1120);
-	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 2640);
+	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 24);
+	ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 72);
+	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1904); // TODO validate
+	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 2360);
 
 
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 440);

--- a/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_13.cpp
+++ b/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_13.cpp
@@ -157,11 +157,11 @@ TEST_F(DramPowerTest_LPDDR4_13, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4560);
-	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1600);
-	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 1200);
-	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 960);
-	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 800);
+	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 3608);
+	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 2720); // TODO validate
+	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 360);
+	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 288);
+	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 240);
 	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 0);
 	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 0);
 	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 0);

--- a/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_14.cpp
+++ b/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_14.cpp
@@ -141,12 +141,12 @@ TEST_F(DramPowerTest_LPDDR4_14, CalcEnergy)
 	ASSERT_EQ(std::round(energy.bank_energy[6].E_pre*1e12), 0);
 	ASSERT_EQ(std::round(energy.bank_energy[7].E_pre*1e12), 0);
 
-	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 3840);
-	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1680);
-	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 1600);
-	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 240);
-	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 160);
-	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 160);
+	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 3504);
+	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 2856); // TODO validate
+	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 480);
+	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 72);
+	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 48);
+	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 48);
 	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 0);
 	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 0);
 	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 0);

--- a/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_15.cpp
+++ b/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_15.cpp
@@ -136,11 +136,11 @@ TEST_F(DramPowerTest_LPDDR4_15, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4800);
-	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1600);
-	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 1040);
-	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 1120);
-	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 1040);
+	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 3680);
+	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 2720); // TODO validate
+	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 312);
+	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 336);
+	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 312);
 	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 0);
 	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 0);
 	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 0);

--- a/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_16.cpp
+++ b/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_16.cpp
@@ -133,16 +133,16 @@ TEST_F(DramPowerTest_LPDDR4_16, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4560);
-	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 880);
-	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 880);
-	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 400);
+	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 2600);
+	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1496); // TODO validate
+	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 264);
+	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 120);
 
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 240);
     ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_pre*1e12), 30);

--- a/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_17.cpp
+++ b/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_17.cpp
@@ -323,16 +323,16 @@ TEST_F(DramPowerTest_LPDDR4_17, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4560);
-	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 880);
-	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 880);
-	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 400);
+	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 2600);
+	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1496); // TODO validate
+	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 264);
+	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 120);
 
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 440);
     ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_pre*1e12), 55);

--- a/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_18.cpp
+++ b/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_18.cpp
@@ -234,16 +234,16 @@ TEST_F(DramPowerTest_LPDDR4_18, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 6400);
-	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1680);
-	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 800);
-	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 1520);
-	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 400);
+	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4272);
+	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 2856); // TODO validate
+	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 240);
+	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 456);
+	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 120);
 
 	ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 40);
 	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_pre*1e12), 5);

--- a/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_3.cpp
+++ b/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_3.cpp
@@ -113,7 +113,7 @@ TEST_F(DramPowerTest_LPDDR4_3, Energy) {
     ASSERT_EQ(std::round(total_energy.E_act*1e12), 392);
     ASSERT_EQ(std::round(total_energy.E_pre*1e12), 415);
     ASSERT_EQ(std::round(total_energy.E_RD*1e12), 452);
-    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 1463);
+    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 1462);
     ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1428);
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 156);
     ASSERT_EQ(std::round(total_energy.total()*1e12), 2878);

--- a/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_6.cpp
+++ b/tests/tests_drampower/core/LPDDR4/lpddr4_test_pattern_6.cpp
@@ -133,5 +133,5 @@ TEST_F(DramPowerTest_LPDDR4_6, Energy) {
     ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 2642);
     ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 2380);
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 779);
-    ASSERT_EQ(std::round(total_energy.total()*1e12), 6833);
+    ASSERT_EQ(std::round(total_energy.total()*1e12), 6832);
 }

--- a/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_12.cpp
+++ b/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_12.cpp
@@ -173,16 +173,16 @@ TEST_F(DramPowerTest_LPDDR5_12, CalcEnergy)
     ASSERT_EQ(std::round(energy.bank_energy[6].E_pre*1e12), 0);
     ASSERT_EQ(std::round(energy.bank_energy[7].E_pre*1e12), 560);
 
-    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 480);
-    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 240);
-    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 240);
-    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 240);
+    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 144);
+    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 72);
+    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 72);
+    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 72);
     ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 0);
     ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 0);
-    ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 80);
-    ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 240);
-    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1120);
-    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 2640);
+    ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 24);
+    ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 72);
+    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1904); // TODO validate
+    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 2360);
 
 
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 440);

--- a/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_14.cpp
+++ b/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_14.cpp
@@ -163,11 +163,11 @@ TEST_F(DramPowerTest_LPDDR5_14, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4560);
-    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1600);
-    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 1200);
-    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 960);
-    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 800);
+    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 3608);
+    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 2720); // TODO
+    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 360);
+    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 288);
+    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 240);
     ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 0);
     ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 0);
     ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 0);

--- a/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_15.cpp
+++ b/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_15.cpp
@@ -144,12 +144,12 @@ TEST_F(DramPowerTest_LPDDR5_15, CalcEnergy)
     ASSERT_EQ(std::round(energy.bank_energy[6].E_pre*1e12), 0);
     ASSERT_EQ(std::round(energy.bank_energy[7].E_pre*1e12), 0);
 
-    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 3840);
-    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1680);
-    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 1600);
-    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 240);
-    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 160);
-    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 160);
+    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 3504);
+    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 2856);
+    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 480);
+    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 72);
+    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 48);
+    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 48);
     ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 0);
     ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 0);
     ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 0);

--- a/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_16.cpp
+++ b/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_16.cpp
@@ -142,11 +142,11 @@ TEST_F(DramPowerTest_LPDDR5_16, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4800);
-    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1600);
-    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 1040);
-    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 1120);
-    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 1040);
+    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 3680);
+    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 2720); // TODO validate
+    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 312);
+    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 336);
+    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 312);
     ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 0);
     ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 0);
     ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 0);

--- a/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_17.cpp
+++ b/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_17.cpp
@@ -144,15 +144,15 @@ TEST_F(DramPowerTest_LPDDR5_17, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4960);
-	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1360);
-	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 1200);
-	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 800);
-	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 400);
-	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 400);
+	ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 3392);
+	ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 2312); // TODO validate
+	ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 360);
+	ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 240);
+	ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 120);
+	ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 120);
 	ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 0);
-	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 400);
+	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 120);
 	ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 0);
 
 	ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 320);
@@ -165,13 +165,13 @@ TEST_F(DramPowerTest_LPDDR5_17, CalcEnergy)
 	ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_pre*1e12), 40);
 	ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_pre*1e12), 40);
 
-	ASSERT_EQ(std::round(total_energy.E_ref_2B*1e12), 1000);
-	ASSERT_EQ(std::round(energy.bank_energy[0].E_ref_2B*1e12), 250);
-	ASSERT_EQ(std::round(energy.bank_energy[1].E_ref_2B*1e12), 125);
-	ASSERT_EQ(std::round(energy.bank_energy[2].E_ref_2B*1e12), 250);
-	ASSERT_EQ(std::round(energy.bank_energy[3].E_ref_2B*1e12), 125);
-	ASSERT_EQ(std::round(energy.bank_energy[4].E_ref_2B*1e12), 125);
+	ASSERT_EQ(std::round(total_energy.E_ref_2B*1e12), 2120);
+	ASSERT_EQ(std::round(energy.bank_energy[0].E_ref_2B*1e12), 530);
+	ASSERT_EQ(std::round(energy.bank_energy[1].E_ref_2B*1e12), 265);
+	ASSERT_EQ(std::round(energy.bank_energy[2].E_ref_2B*1e12), 530);
+	ASSERT_EQ(std::round(energy.bank_energy[3].E_ref_2B*1e12), 265);
+	ASSERT_EQ(std::round(energy.bank_energy[4].E_ref_2B*1e12), 265);
 	ASSERT_EQ(std::round(energy.bank_energy[5].E_ref_2B*1e12), 0);
-	ASSERT_EQ(std::round(energy.bank_energy[6].E_ref_2B*1e12), 125);
+	ASSERT_EQ(std::round(energy.bank_energy[6].E_ref_2B*1e12), 265);
 	ASSERT_EQ(std::round(energy.bank_energy[7].E_ref_2B*1e12), 0);
 };

--- a/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_18.cpp
+++ b/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_18.cpp
@@ -138,16 +138,16 @@ TEST_F(DramPowerTest_LPDDR5_18, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4560);
-    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 880);
-    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 880);
-    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 400);
+    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 2600);
+    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1496);
+    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 264);
+    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 120);
 
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 240);
     ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_pre*1e12), 30);

--- a/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_19.cpp
+++ b/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_19.cpp
@@ -327,16 +327,16 @@ TEST_F(DramPowerTest_LPDDR5_19, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4560);
-    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 880);
-    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 880);
-    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 400);
+    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 2600);
+    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1496);
+    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 264);
+    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 120);
 
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 440);
     ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_pre*1e12), 55);

--- a/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_20.cpp
+++ b/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_20.cpp
@@ -238,16 +238,16 @@ TEST_F(DramPowerTest_LPDDR5_20, CalcEnergy)
 	auto energy = ddr->calcCoreEnergy(125);
 	auto total_energy = energy.aggregated_bank_energy();
 
-    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 6400);
-    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1680);
-    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 800);
-    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 1520);
-    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 400);
-    ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 400);
+    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4272);
+    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 2856);
+    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 240);
+    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 456);
+    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 120);
+    ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 120);
 
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 40);
     ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_pre*1e12), 5);

--- a/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_21.cpp
+++ b/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_21.cpp
@@ -125,16 +125,16 @@ TEST_F(DramPowerTest_LPDDR5_21, CalcEnergy)
     auto energy = ddr->calcCoreEnergy(125);
     auto total_energy = energy.aggregated_bank_energy();
 
-    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 4320);
-    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 480);
-    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 480);
-    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 480);
-    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 480);
-    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 480);
-    ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 480);
-    ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 480);
-    ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 480);
-    ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 480);
+    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 1968);
+    ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 816);
+    ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_act*1e12), 144);
+    ASSERT_EQ(std::round(energy.bank_energy[1].E_bg_act*1e12), 144);
+    ASSERT_EQ(std::round(energy.bank_energy[2].E_bg_act*1e12), 144);
+    ASSERT_EQ(std::round(energy.bank_energy[3].E_bg_act*1e12), 144);
+    ASSERT_EQ(std::round(energy.bank_energy[4].E_bg_act*1e12), 144);
+    ASSERT_EQ(std::round(energy.bank_energy[5].E_bg_act*1e12), 144);
+    ASSERT_EQ(std::round(energy.bank_energy[6].E_bg_act*1e12), 144);
+    ASSERT_EQ(std::round(energy.bank_energy[7].E_bg_act*1e12), 144);
 
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 320);
     ASSERT_EQ(std::round(energy.bank_energy[0].E_bg_pre*1e12), 40);

--- a/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_3.cpp
+++ b/tests/tests_drampower/core/LPDDR5/lpddr5_test_pattern_3.cpp
@@ -113,7 +113,7 @@ TEST_F(DramPowerTest_LPDDR5_3, Energy) {
     ASSERT_EQ(std::round(total_energy.E_act*1e12), 392);
     ASSERT_EQ(std::round(total_energy.E_pre*1e12), 415);
     ASSERT_EQ(std::round(total_energy.E_RD*1e12), 226);
-    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 1463);
+    ASSERT_EQ(std::round(total_energy.E_bg_act*1e12), 1462);
     ASSERT_EQ(std::round(energy.E_bg_act_shared*1e12), 1428);
     ASSERT_EQ(std::round(total_energy.E_bg_pre*1e12), 156);
     ASSERT_EQ(std::round(total_energy.total()*1e12), 2652);

--- a/tests/tests_drampower/resources/lpddr4.json
+++ b/tests/tests_drampower/resources/lpddr4.json
@@ -79,7 +79,7 @@
       "RTRS": 0
     },
     "bankwisespec":{
-      "factRho":0.5,
+      "factRho":0.058823529412,
       "factSigma": 1.0,
       "pasrMode": 0,
       "hasPASR": false

--- a/tests/tests_drampower/resources/lpddr5.json
+++ b/tests/tests_drampower/resources/lpddr5.json
@@ -101,7 +101,7 @@
       "pbR2pbR": 0
     },
     "bankwisespec":{
-      "factRho":0.5
+      "factRho":0.058823529412
     },
     "memimpedancespec": {
       "ck_termination": true,


### PR DESCRIPTION
- ensure consistent naming conventions
- unify I_rho calculations/definition across DDR and LPDDR