### PR TITLE
fix: remove rank endRefreshTime

### DIFF
--- a/src/DRAMPower/DRAMPower/dram/Rank.cpp
+++ b/src/DRAMPower/DRAMPower/dram/Rank.cpp
@@ -8,11 +8,8 @@ Rank::Rank(std::size_t numBanks)
     : banks(numBanks)
 {};
 
-bool Rank::isActive(timestamp_t timestamp) {
-    if ( timestamp < this->endRefreshTime ) {
-        std::cout << "[WARN] Rank::isActive() -> timestamp (" << timestamp <<") < "  << "endRefreshTime (" << this->endRefreshTime << ")"  << std::endl;
-    }
-    return countActiveBanks() > 0 || timestamp < this->endRefreshTime;
+bool Rank::isActive() {
+    return countActiveBanks() > 0;
 }
 
 std::size_t Rank::countActiveBanks() const {
@@ -24,11 +21,8 @@ std::size_t Rank::countActiveBanks() const {
 
 void Rank::serialize(std::ostream& stream) const {
     stream.write(reinterpret_cast<const char*>(&memState), sizeof(memState));
-    stream.write(reinterpret_cast<const char *>(&endRefreshTime), sizeof(endRefreshTime));
-
     stream.write(reinterpret_cast<const char* >(&counter.selfRefresh), sizeof(counter.selfRefresh));
     stream.write(reinterpret_cast<const char* >(&counter.deepSleepMode), sizeof(counter.deepSleepMode));
-    stream.write(reinterpret_cast<const char* >(&endRefreshTime), sizeof(endRefreshTime));
     cycles.pre.serialize(stream);
     cycles.act.serialize(stream);
     cycles.ref.serialize(stream);
@@ -44,11 +38,8 @@ void Rank::serialize(std::ostream& stream) const {
 
 void Rank::deserialize(std::istream& stream) {
     stream.read(reinterpret_cast<char *>(&memState), sizeof(memState));
-    stream.read(reinterpret_cast<char *>(&endRefreshTime), sizeof(endRefreshTime));
-
     stream.read(reinterpret_cast<char* >(&counter.selfRefresh), sizeof(counter.selfRefresh));
     stream.read(reinterpret_cast<char* >(&counter.deepSleepMode), sizeof(counter.deepSleepMode));
-    stream.read(reinterpret_cast<char* >(&endRefreshTime), sizeof(endRefreshTime));
     cycles.pre.deserialize(stream);
     cycles.act.deserialize(stream);
     cycles.ref.deserialize(stream);

--- a/src/DRAMPower/DRAMPower/dram/Rank.h
+++ b/src/DRAMPower/DRAMPower/dram/Rank.h
@@ -39,7 +39,6 @@ public:
 		uint64_t selfRefresh = 0;
 		uint64_t deepSleepMode = 0;
 	} counter = { 0 };
-	timestamp_t endRefreshTime = 0;
 	std::vector<Bank> banks;
 
 public:
@@ -48,7 +47,7 @@ public:
 
 // Functions
 public:
-	bool isActive(timestamp_t timestamp);
+	bool isActive();
 	std::size_t countActiveBanks() const;
 // Overrides
 	void serialize(std::ostream& stream) const override;

--- a/src/DRAMPower/DRAMPower/standards/ddr4/DDR4Core.cpp
+++ b/src/DRAMPower/DRAMPower/standards/ddr4/DDR4Core.cpp
@@ -87,7 +87,7 @@ void DDR4Core::handlePre(Rank &rank, Bank &bank, timestamp_t timestamp) {
     bank.bankState = Bank::BankState::BANK_PRECHARGED;
     bank.cycles.act.close_interval(timestamp);
     bank.latestPre = timestamp;                                                // used for earliest power down calculation
-    if ( !rank.isActive(timestamp) )                                            // stop rank active interval if no more banks active
+    if ( !rank.isActive() )                                            // stop rank active interval if no more banks active
     {
         // active counter increased if at least 1 bank is active, precharge counter increased if all banks are precharged
         rank.cycles.act.close_interval(timestamp);
@@ -103,7 +103,6 @@ void DDR4Core::handlePreAll(Rank &rank, timestamp_t timestamp) {
 void DDR4Core::handleRefAll(std::size_t rank_idx, timestamp_t timestamp) {
     auto timestamp_end = timestamp + m_memSpec.tRFC;
     auto& rank = m_ranks[rank_idx];
-    rank.endRefreshTime = timestamp_end;
     rank.cycles.act.start_interval_if_not_running(timestamp);
     //rank.cycles.pre.close_interval(timestamp);
     for (std::size_t bank_idx = 0; bank_idx < rank.banks.size(); ++bank_idx) {
@@ -123,7 +122,7 @@ void DDR4Core::handleRefAll(std::size_t rank_idx, timestamp_t timestamp) {
             bank.bankState = Bank::BankState::BANK_PRECHARGED;
             bank.cycles.act.close_interval(timestamp_end);
             // stop rank active interval if no more banks active
-            if (!rank.isActive(timestamp_end))                                  // stop rank active interval if no more banks active
+            if (!rank.isActive())                                  // stop rank active interval if no more banks active
             {
                 rank.cycles.act.close_interval(timestamp_end);
                 //rank.cycles.pre.start_interval(timestamp_end);
@@ -228,7 +227,7 @@ void DDR4Core::handlePowerDownActExit(std::size_t rank_idx, timestamp_t timestam
         }
         // Activate rank if at least one bank is active
         // At least one bank must be active for PDA -> remove if statement?
-        if(rank.isActive(exitTime))
+        if(rank.isActive())
             rank.cycles.act.start_interval(exitTime); 
 
     });

--- a/src/DRAMPower/DRAMPower/standards/ddr5/DDR5Core.cpp
+++ b/src/DRAMPower/DRAMPower/standards/ddr5/DDR5Core.cpp
@@ -77,7 +77,7 @@ void DDR5Core::handleAct(Rank &rank, Bank &bank, timestamp_t timestamp) {
 
     bank.cycles.act.start_interval(timestamp);
 
-    if ( !rank.isActive(timestamp) ) {
+    if ( !rank.isActive() ) {
         rank.cycles.act.start_interval(timestamp);
     };
 
@@ -93,7 +93,7 @@ void DDR5Core::handlePre(Rank &rank, Bank &bank, timestamp_t timestamp) {
     bank.latestPre = timestamp;
     bank.bankState = Bank::BankState::BANK_PRECHARGED;
 
-    if ( !rank.isActive(timestamp) ) {
+    if ( !rank.isActive() ) {
         rank.cycles.act.close_interval(timestamp);
     }
 }
@@ -128,7 +128,6 @@ void DDR5Core::handleRefAll(std::size_t rank_idx, timestamp_t timestamp) {
         handleRefreshOnBank(rank_idx, bank_idx, timestamp, m_memSpec.tRFC, counter);
     }
 
-    rank.endRefreshTime = timestamp + m_memSpec.tRFC;
 }
 
 void DDR5Core::handleRefreshOnBank(std::size_t rank_idx, std::size_t bank_idx, timestamp_t timestamp, uint64_t timing, uint64_t & counter){
@@ -136,7 +135,7 @@ void DDR5Core::handleRefreshOnBank(std::size_t rank_idx, std::size_t bank_idx, t
     auto& rank = m_ranks[rank_idx];
     auto& bank = rank.banks[bank_idx];
 
-    if (!rank.isActive(timestamp)) {
+    if (!rank.isActive()) {
         rank.cycles.act.start_interval(timestamp);
     }
 
@@ -156,7 +155,7 @@ void DDR5Core::handleRefreshOnBank(std::size_t rank_idx, std::size_t bank_idx, t
         bank.bankState = Bank::BankState::BANK_PRECHARGED;
         bank.cycles.act.close_interval(timestamp_end);
 
-        if (!rank.isActive(timestamp_end)) {
+        if (!rank.isActive()) {
             rank.cycles.act.close_interval(timestamp_end);
         }
     });

--- a/src/DRAMPower/DRAMPower/standards/lpddr4/LPDDR4Core.cpp
+++ b/src/DRAMPower/DRAMPower/standards/lpddr4/LPDDR4Core.cpp
@@ -73,7 +73,7 @@ void LPDDR4Core::handleAct(Rank &rank, Bank &bank, timestamp_t timestamp) {
 
     bank.cycles.act.start_interval(timestamp);
 
-    if (!rank.isActive(timestamp)) {
+    if (!rank.isActive()) {
         rank.cycles.act.start_interval(timestamp);
     }
 
@@ -89,7 +89,7 @@ void LPDDR4Core::handlePre(Rank &rank, Bank &bank, timestamp_t timestamp) {
     bank.latestPre = timestamp;
     bank.bankState = Bank::BankState::BANK_PRECHARGED;
 
-    if (!rank.isActive(timestamp)) {
+    if (!rank.isActive()) {
         rank.cycles.act.close_interval(timestamp);
     }
 }
@@ -105,7 +105,7 @@ void LPDDR4Core::handleRefreshOnBank(std::size_t rank_idx, std::size_t bank_idx,
     auto& rank = m_ranks[rank_idx];
     auto& bank = rank.banks[bank_idx];
 
-    if (!rank.isActive(timestamp)) {
+    if (!rank.isActive()) {
         rank.cycles.act.start_interval(timestamp);
     }
 
@@ -122,7 +122,7 @@ void LPDDR4Core::handleRefreshOnBank(std::size_t rank_idx, std::size_t bank_idx,
         bank.bankState = Bank::BankState::BANK_PRECHARGED;
         bank.cycles.act.close_interval(timestamp_end);
 
-        if (!rank.isActive(timestamp_end)) {
+        if (!rank.isActive()) {
             rank.cycles.act.close_interval(timestamp_end);
         }
     });
@@ -134,7 +134,6 @@ void LPDDR4Core::handleRefAll(std::size_t rank_idx, timestamp_t timestamp) {
         auto& counter = rank.banks[bank_idx].counter.refAllBank;
         handleRefreshOnBank(rank_idx, bank_idx, timestamp, m_memSpec.tRFC, counter);
     }
-    rank.endRefreshTime = timestamp + m_memSpec.tRFC;
 }
 
 void LPDDR4Core::handleRefPerBank(std::size_t rank_idx, std::size_t bank_idx, timestamp_t timestamp) {

--- a/src/DRAMPower/DRAMPower/standards/lpddr5/LPDDR5Core.cpp
+++ b/src/DRAMPower/DRAMPower/standards/lpddr5/LPDDR5Core.cpp
@@ -86,7 +86,7 @@ void LPDDR5Core::handleAct(Rank &rank, Bank &bank, timestamp_t timestamp) {
 
     bank.cycles.act.start_interval(timestamp);
 
-    if ( !rank.isActive(timestamp) ) {
+    if ( !rank.isActive() ) {
         rank.cycles.act.start_interval(timestamp);
     }
 
@@ -102,7 +102,7 @@ void LPDDR5Core::handlePre(Rank &rank, Bank &bank, timestamp_t timestamp) {
     bank.latestPre = timestamp;
     bank.bankState = Bank::BankState::BANK_PRECHARGED;
 
-    if (!rank.isActive(timestamp)) {
+    if (!rank.isActive()) {
         rank.cycles.act.close_interval(timestamp);
     }
 }
@@ -133,14 +133,13 @@ void LPDDR5Core::handleRefAll(std::size_t rank_idx, timestamp_t timestamp) {
         auto& counter = rank.banks[bank_idx].counter.refAllBank;
         handleRefreshOnBank(rank_idx, bank_idx, timestamp, m_memSpec.tRFC, counter);
     }
-    rank.endRefreshTime = timestamp + m_memSpec.tRFC;
 }
 
 void LPDDR5Core::handleRefreshOnBank(std::size_t rank_idx, std::size_t bank_idx, timestamp_t timestamp, uint64_t timing, uint64_t & counter){
     ++counter;
     auto& rank = m_ranks[rank_idx];
     auto& bank = rank.banks[bank_idx];
-    if (!rank.isActive(timestamp)) {
+    if (!rank.isActive()) {
         rank.cycles.act.start_interval(timestamp);
     }
     bank.bankState = Bank::BankState::BANK_ACTIVE;
@@ -156,7 +155,7 @@ void LPDDR5Core::handleRefreshOnBank(std::size_t rank_idx, std::size_t bank_idx,
         bank.bankState = Bank::BankState::BANK_PRECHARGED;
         bank.cycles.act.close_interval(timestamp_end);
 
-        if (!rank.isActive(timestamp_end)) {
+        if (!rank.isActive()) {
             rank.cycles.act.close_interval(timestamp_end);
         }
     });

--- a/src/DRAMPower/DRAMPower/standards/lpddr6/LPDDR6Core.cpp
+++ b/src/DRAMPower/DRAMPower/standards/lpddr6/LPDDR6Core.cpp
@@ -85,11 +85,7 @@ void LPDDR6Core::handleAct(Rank &rank, Bank &bank, timestamp_t timestamp) {
     bank.counter.act++;
 
     bank.cycles.act.start_interval(timestamp);
-
-    if ( !rank.isActive(timestamp) ) {
-        rank.cycles.act.start_interval(timestamp);
-    }
-
+    rank.cycles.act.start_interval_if_not_running(timestamp);
     bank.bankState = Bank::BankState::BANK_ACTIVE;
 }
 
@@ -102,7 +98,7 @@ void LPDDR6Core::handlePre(Rank &rank, Bank &bank, timestamp_t timestamp) {
     bank.latestPre = timestamp;
     bank.bankState = Bank::BankState::BANK_PRECHARGED;
 
-    if (!rank.isActive(timestamp)) {
+    if (!rank.isActive()) {
         rank.cycles.act.close_interval(timestamp);
     }
 }
@@ -120,7 +116,6 @@ void LPDDR6Core::handleRefDualBanks(std::size_t rank_idx, std::size_t bank_idx1,
     // TODO timing
     handleRefreshOnBank(rank_idx, bank_idx1, timestamp, m_memSpec.tRFCDB, counter1);
     handleRefreshOnBank(rank_idx, bank_idx2, timestamp, m_memSpec.tRFCDB, counter2);
-    // TODO rank.endRefreshTime?
 }
 
 void LPDDR6Core::handleRefAll(std::size_t rank_idx, timestamp_t timestamp) {
@@ -131,16 +126,13 @@ void LPDDR6Core::handleRefAll(std::size_t rank_idx, timestamp_t timestamp) {
         handleRefreshOnBank(rank_idx, bank_idx, timestamp, m_memSpec.tRFCAB, counter);
     }
     // TODO timing
-    rank.endRefreshTime = timestamp + m_memSpec.tRFCAB;
 }
 
 void LPDDR6Core::handleRefreshOnBank(std::size_t rank_idx, std::size_t bank_idx, timestamp_t timestamp, uint64_t timing, uint64_t & counter){
     ++counter;
     auto& rank = m_ranks[rank_idx];
     auto& bank = rank.banks[bank_idx];
-    if (!rank.isActive(timestamp)) {
-        rank.cycles.act.start_interval(timestamp);
-    }
+    rank.cycles.act.start_interval_if_not_running(timestamp);
     bank.bankState = Bank::BankState::BANK_ACTIVE;
     auto timestamp_end = timestamp + timing;
     bank.refreshEndTime = timestamp_end;
@@ -154,7 +146,7 @@ void LPDDR6Core::handleRefreshOnBank(std::size_t rank_idx, std::size_t bank_idx,
         bank.bankState = Bank::BankState::BANK_PRECHARGED;
         bank.cycles.act.close_interval(timestamp_end);
 
-        if (!rank.isActive(timestamp_end)) {
+        if (!rank.isActive()) {
             rank.cycles.act.close_interval(timestamp_end);
         }
     });


### PR DESCRIPTION
Removed `endRefreshTime` in Rank implementation as this check is not necessary to compute the `isActive` condition. The condition is computed with the following expression `countActiveBanks() > 0`.